### PR TITLE
fix: add AI-first principles to prevent human-only guidance

### DIFF
--- a/create-skill/SKILL.md
+++ b/create-skill/SKILL.md
@@ -53,6 +53,15 @@ Prefer concise examples over verbose explanations.
 
 Each workflow skill defines its own appropriate steps. Never force a template step count onto workflows - a bug fix workflow has different needs than a feature workflow. Design steps based on what the specific task requires.
 
+### AI-First Principles
+
+Skills are executed by AI, not humans. Avoid principles that only apply to human workflows:
+- No time-boxing (AI doesn't fatigue)
+- No human-to-human collaboration tips
+- No "take breaks" or pacing advice
+
+Focus on principles that improve AI execution: clarity, structure, explicit criteria, and verifiable outputs.
+
 ### Set Appropriate Degrees of Freedom
 
 Match the level of specificity to the task's fragility and variability:

--- a/research/SKILL.md
+++ b/research/SKILL.md
@@ -70,6 +70,7 @@ Explore codebase and online sources to gather information on a topic.
 - **Authoritative sources** - Prefer official docs and proven engineering blogs
 - **Context matters** - Relate findings back to the specific project
 - **Cite sources** - Always include URLs for external information
+- **AI-first** - Focus on clarity, structure, and verifiable outputs (no human-only advice like time-boxing)
 
 ## Code Rules
 


### PR DESCRIPTION
## Summary

Add AI-first principles to ensure skills focus on AI execution rather than human-only advice.

**create-skill**: Added "AI-First Principles" section to Core Principles:
- No time-boxing (AI doesn't fatigue)
- No human-to-human collaboration tips
- No "take breaks" or pacing advice
- Focus on clarity, structure, explicit criteria, verifiable outputs

**research**: Added AI-first principle to existing principles list.

Closes #8

## Test Plan

- [x] Verify markdown syntax valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)