### PR TITLE
fix: require explicit passing of global state instead of null defaults

### DIFF
--- a/create-feature/SKILL.md
+++ b/create-feature/SKILL.md
@@ -162,4 +162,5 @@ Add validateCredentials() to verify password against bcrypt hash.
 - Keep functions small enough to fit in your head
 - Do not abstract until you see the pattern three times
 - Prefer explicit over implicit - no magic
+- Never default parameters to null with singleton fallback - require explicit passing
 - Always read file before editing - never propose changes to code you haven't read

--- a/refactor/SKILL.md
+++ b/refactor/SKILL.md
@@ -174,6 +174,7 @@ Replace inline validation with helper.
 - Keep functions small enough to fit in your head
 - Do not abstract until you see the pattern three times
 - Prefer explicit over implicit - no magic
+- Never default parameters to null with singleton fallback - require explicit passing
 - Always read file before editing - never propose changes to code you haven't read
 - Use pure functions, immutability, no side effects
 - Flow data through parameters, not global state

--- a/research/SKILL.md
+++ b/research/SKILL.md
@@ -79,6 +79,7 @@ Explore codebase and online sources to gather information on a topic.
 - Keep functions small enough to fit in your head
 - Do not abstract until you see the pattern three times
 - Prefer explicit over implicit - no magic
+- Never default parameters to null with singleton fallback - require explicit passing
 - Always read file before editing - never propose changes to code you haven't read
 - Use pure functions, immutability, no side effects
 - Flow data through parameters, not global state

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -93,6 +93,7 @@ Use Review Report format below. Group by severity.
 - Keep functions small enough to fit in your head
 - Do not abstract until you see the pattern three times
 - Prefer explicit over implicit - no magic
+- Never default parameters to null with singleton fallback - require explicit passing
 - Always read file before editing - never propose changes to code you haven't read
 - Use pure functions, immutability, no side effects
 - Flow data through parameters, not global state


### PR DESCRIPTION
## Summary

Add code rule to prevent the anti-pattern of defaulting parameters to null with singleton fallback:

```typescript
// BAD - don't do this
function doSomething(config: Config | null = null) {
  const cfg = config ?? GlobalConfig.getInstance();
}

// GOOD - require explicit passing
function doSomething(config: Config) {
  // config always provided by caller
}
```

## Changes

Added to Code Rules in all 4 skills:
- `create-feature/SKILL.md`
- `refactor/SKILL.md`
- `review/SKILL.md`
- `research/SKILL.md`

Closes #30